### PR TITLE
[alsa-lib] Add local build tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-results
+results/
+inspec.lock

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ The Advanced Linux Sound Architecture (ALSA) provides audio and MIDI functionali
 
 ## Type of Package
 
-Binary package
+Library package
 
 ### Use as Dependency
 
-Binary packages can be set as runtime or build time dependencies. See [Defining your dependencies](https://www.habitat.sh/docs/developing-packages/developing-packages/#sts=Define%20Your%20Dependencies) for more information.
+Library packages can be set as runtime or build time dependencies, however they are typically used as buildtime dependencies. See [Defining your dependencies](https://www.habitat.sh/docs/developing-packages/developing-packages/#sts=Define%20Your%20Dependencies) for more information.
 
 To add core/alsa-lib as a dependency, you can add one of the following to your plan file.
 
@@ -25,7 +25,7 @@ To add core/alsa-lib as a dependency, you can add one of the following to your p
 
 > pkg_deps=(core/alsa-lib)
 
-### Use as Tool
+### Use as a Library
 
 #### Installation
 
@@ -50,6 +50,33 @@ For example:
 ★ Binlinked aserver from core/alsa-lib/1.1.9/20200811102940 to /bin/aserver
 [8][default:/src/alsa-lib:0]#
 ```
+
+#### Viewing library files
+
+To view the library files first get the habitat installation directory
+
+```bash
+hab pkg path core/alsa-lib
+/hab/pkgs/core/alsa-lib/1.1.9/20200811102940
+```
+
+Then list the libraries, for example:
+
+```bash
+ls -1 $(hab pkg path core/alsa-lib)
+...
+...
+bin
+include
+lib
+share
+```
+
+### Use as Tool
+
+#### Installation
+
+Same as above.
 
 #### Using an example binary
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,40 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# alsa-lib
+
+This package provides the ALSA library.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+Typically this is a runtime dependency that can be added to your
+plan.sh:
+
+    pkg_deps=(core/alsa-lib)
+
+## Testing
+
+Run the tests after building the package like so:
+
+```bash
+hab studio build alsa-lib
+source results/last_build.env
+hab studio run "./alsa-lib/tests/test.sh $pkg_ident"
+```
+
+Sample output:
+
+```bash
+✓ Installed core/alsa-lib/1.1.8/20190530132818
+★ Install of core/alsa-lib/1.1.8/20190530132818 complete with 1 new packages installed.
+1..4
+ok 1 package directory for package ident core/alsa-lib/1.1.8/20190530132818 exists
+ok 2 libraries are dynamically linked
+ok 3 aserver is dynamically linked
+ok 4 aserver help command works
+```

--- a/README.md
+++ b/README.md
@@ -1,40 +1,64 @@
+[![Build Status](https://chefcorp-partnerengineering.visualstudio.com/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.alsa-lib?branchName=master)](https://chefcorp-partnerengineering.visualstudio.com/Chef%20Base%20Plans/_build/latest?definitionId=196&branchName=master)
 # alsa-lib
 
-This package provides the ALSA library.
+The Advanced Linux Sound Architecture (ALSA) provides audio and MIDI functionality to the Linux operating system.  See [documentation](https://alsa-project.org/wiki/Main_Page)
 
 ## Maintainers
 
-* The Habitat Maintainers: <humans@habitat.sh>
+* The Core Planners: <chef-core-planners@chef.io>
 
 ## Type of Package
 
 Binary package
 
-## Usage
+### Use as Dependency
 
-Typically this is a runtime dependency that can be added to your
-plan.sh:
+Binary packages can be set as runtime or build time dependencies. See [Defining your dependencies](https://www.habitat.sh/docs/developing-packages/developing-packages/#sts=Define%20Your%20Dependencies) for more information.
 
-    pkg_deps=(core/alsa-lib)
+To add core/alsa-lib as a dependency, you can add one of the following to your plan file.
 
-## Testing
+##### Buildtime Dependency
 
-Run the tests after building the package like so:
+> pkg_build_deps=(core/alsa-lib)
+
+##### Runtime dependency
+
+> pkg_deps=(core/alsa-lib)
+
+### Use as Tool
+
+#### Installation
+
+To install this plan, you should run the following commands to first install, and then link the binaries this plan creates.
+
+``hab pkg install core/alsa-lib --binlink``
+
+will add the following binary to the PATH:
+
+* /bin/aserver
+
+For example:
 
 ```bash
-hab studio build alsa-lib
-source results/last_build.env
-hab studio run "./alsa-lib/tests/test.sh $pkg_ident"
+[7][default:/src/alsa-lib:100]# hab pkg install core/alsa-lib --binlink
+» Installing core/alsa-lib
+☁ Determining latest version of core/alsa-lib in the 'stable' channel
+→ Found newer installed version (core/alsa-lib/1.1.9/20200811102940) than remote version (core/alsa-lib/1.1.9/20200404040530)
+→ Using core/alsa-lib/1.1.9/20200811102940
+★ Install of core/alsa-lib/1.1.9/20200811102940 complete with 0 new packages installed.
+» Binlinking aserver from core/alsa-lib/1.1.9/20200811102940 into /bin
+★ Binlinked aserver from core/alsa-lib/1.1.9/20200811102940 to /bin/aserver
+[8][default:/src/alsa-lib:0]#
 ```
 
-Sample output:
+#### Using an example binary
+
+You can now use the binary as normal.  For example:
+
+``/bin/aserver --help`` or ``aserver --help``
 
 ```bash
-✓ Installed core/alsa-lib/1.1.8/20190530132818
-★ Install of core/alsa-lib/1.1.8/20190530132818 complete with 1 new packages installed.
-1..4
-ok 1 package directory for package ident core/alsa-lib/1.1.8/20190530132818 exists
-ok 2 libraries are dynamically linked
-ok 3 aserver is dynamically linked
-ok 4 aserver help command works
+[10][default:/src/alsa-lib:0]# aserver --help
+Usage: aserver [OPTIONS] server
+--help                  help
 ```

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+plan_name: 'alsa-lib'

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,1 +1,3 @@
 plan_name: 'alsa-lib'
+library_filename: 'libasound.so'
+pkgconfig_filename: 'alsa.pc'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,4 +15,4 @@ resources:
 
 # Execute the stages from the main pipeline template
 stages:
-  - template: azure-pipelines.yml@plan_builder
+  - template: azure-pipelines-package-install.yml@plan_builder

--- a/botanist.yml
+++ b/botanist.yml
@@ -1,0 +1,4 @@
+---
+owners:
+  - "@smacfarlane"
+  - "@habitat-sh/habitat-core-plans-maintainers"

--- a/controls/alsa-lib_exists.rb
+++ b/controls/alsa-lib_exists.rb
@@ -18,11 +18,9 @@ control 'core-plans-alsa-lib-exists' do
     its('stderr') { should be_empty }
   end
 
-  ["aserver"].each do |binary_name|
-      command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", binary_name)
-      describe file(command_full_path) do
-        it { should exist }
-        it { should be_executable }
-      end
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", "aserver")
+  describe file(command_full_path) do
+    it { should exist }
+    it { should be_executable }
   end
 end

--- a/controls/alsa-lib_exists.rb
+++ b/controls/alsa-lib_exists.rb
@@ -1,0 +1,28 @@
+title 'Tests to confirm alsa-lib exists'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'alsa-lib')
+
+control 'core-plans-alsa-lib-exists' do
+  impact 1.0
+  title 'Ensure alsa-lib exists'
+  desc '
+  Verify alsa-lib by ensuring bin/aserver 
+  (1) exists and
+  (2) is executable'
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
+  end
+
+  ["aserver"].each do |binary_name|
+      command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", binary_name)
+      describe file(command_full_path) do
+        it { should exist }
+        it { should be_executable }
+      end
+  end
+end

--- a/controls/alsa-lib_exists.rb
+++ b/controls/alsa-lib_exists.rb
@@ -15,7 +15,6 @@ control 'core-plans-alsa-lib-exists' do
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
-    its('stderr') { should be_empty }
   end
 
   command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", "aserver")

--- a/controls/alsa-lib_library_exists.rb
+++ b/controls/alsa-lib_library_exists.rb
@@ -33,6 +33,5 @@ control 'core-plans-alsa-lib-library-exists' do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
     its('stdout') { should match /Version: #{plan_pkg_version}/ }
-    its('stderr') { should be_empty }
   end
 end

--- a/controls/alsa-lib_library_exists.rb
+++ b/controls/alsa-lib_library_exists.rb
@@ -1,0 +1,38 @@
+title 'Tests to confirm alsa-lib library exists'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'alsa-lib')
+
+control 'core-plans-alsa-lib-library-exists' do
+  impact 1.0
+  title 'Ensure alsa-lib library exists'
+  desc '
+  Verify alsa-lib library by ensuring that 
+  (1) its installation directory exists; 
+  (2) the library exists; 
+  (3) its pkgconfig metadata contains the expected version
+  '
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+
+  library_filename = input('library_filename', value: 'libasound.so')
+  library_full_path = File.join(plan_installation_directory.stdout.strip, 'lib', library_filename)
+  describe file(library_full_path) do
+    it { should exist }
+  end
+
+  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
+  pkgconfig_filename = input('pkgconfig_filename', value: 'alsa.pc')
+  pkgconfig_full_path = File.join(plan_installation_directory.stdout.strip, 'lib', 'pkgconfig', pkgconfig_filename)
+  describe command("cat #{pkgconfig_full_path}") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /Version: #{plan_pkg_version}/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/controls/alsa-lib_works.rb
+++ b/controls/alsa-lib_works.rb
@@ -1,0 +1,32 @@
+title 'Tests to confirm alsa-lib works as expected'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'alsa-lib')
+
+control 'core-plans-alsa-lib-works' do
+  impact 1.0
+  title 'Ensure alsa-lib works as expected'
+  desc '
+  Verify alsa-lib by ensuring that
+  (1) its installation directory exists 
+  (2) it returns the expected version
+  '
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
+  end
+  
+  plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
+  ["aserver"].each do |binary_name|
+    command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", binary_name)
+    describe command("#{command_full_path} --help") do
+      its('exit_status') { should eq 0 }
+      its('stderr') { should_not be_empty }
+      its('stderr') { should match /Usage:\s+[^\s]*\s+\[OPTIONS\]\s+server/ }
+      its('stdout') { should be_empty }
+    end
+  end
+end

--- a/controls/alsa-lib_works.rb
+++ b/controls/alsa-lib_works.rb
@@ -16,15 +16,12 @@ control 'core-plans-alsa-lib-works' do
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
-    its('stderr') { should be_empty }
   end
   
   plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
   command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", "aserver")
-  describe command("#{command_full_path} --help") do
+  describe command("#{command_full_path} --help 2>&1") do
     its('exit_status') { should eq 0 }
-    its('stderr') { should_not be_empty }
-    its('stderr') { should match /Usage:\s+[^\s]*\s+\[OPTIONS\]\s+server/ }
-    its('stdout') { should be_empty }
+    its('stdout') { should match /Usage:\s+[^\s]*\s+\[OPTIONS\]\s+server/ }
   end
 end

--- a/controls/alsa-lib_works.rb
+++ b/controls/alsa-lib_works.rb
@@ -9,7 +9,7 @@ control 'core-plans-alsa-lib-works' do
   desc '
   Verify alsa-lib by ensuring that
   (1) its installation directory exists 
-  (2) it returns the expected version
+  (2) --help returns the expected response
   '
   
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
@@ -20,13 +20,11 @@ control 'core-plans-alsa-lib-works' do
   end
   
   plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
-  ["aserver"].each do |binary_name|
-    command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", binary_name)
-    describe command("#{command_full_path} --help") do
-      its('exit_status') { should eq 0 }
-      its('stderr') { should_not be_empty }
-      its('stderr') { should match /Usage:\s+[^\s]*\s+\[OPTIONS\]\s+server/ }
-      its('stdout') { should be_empty }
-    end
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", "aserver")
+  describe command("#{command_full_path} --help") do
+    its('exit_status') { should eq 0 }
+    its('stderr') { should_not be_empty }
+    its('stderr') { should match /Usage:\s+[^\s]*\s+\[OPTIONS\]\s+server/ }
+    its('stdout') { should be_empty }
   end
 end

--- a/hooks/run
+++ b/hooks/run
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-exec 2>&1
-
-while true; do
-  echo "Sleeping ..."
-  sleep 10
-done

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,7 +1,7 @@
-name: {plan}
-title: Habitat Core Plan {plan}
+name: alsa-lib
+title: Habitat Core Plan alsa-lib
 maintainer: "The Core Planners <chef-core-planners@chef.io>"
-summary: InSpec controls for testing Habitat Core Plan {plan}
+summary: InSpec controls for testing Habitat Core Plan alsa-lib
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 4.18.108'

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,40 @@
+pkg_name=alsa-lib
+pkg_origin=core
+pkg_version=1.1.9
+pkg_description="The Advanced Linux Sound Architecture (ALSA) provides audio and MIDI functionality to the Linux operating system."
+pkg_upstream_url=https://alsa-project.org/
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=("LGPL-2.1-or-later")
+pkg_source="ftp://ftp.alsa-project.org/pub/lib/${pkg_name}-${pkg_version}.tar.bz2"
+pkg_shasum=488373aef5396682f3a411a6d064ae0ad196b9c96269d0bb912fbdeec94b994b
+pkg_deps=(
+  core/glibc
+)
+pkg_build_deps=(
+  core/diffutils
+  core/file
+  core/gcc
+  core/m4
+  core/make
+)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+pkg_pconfig_dirs=(lib/pkgconfig)
+
+do_prepare() {
+  if [[ ! -r /usr/bin/file ]]; then
+    ln -sv "$(pkg_path_for file)/bin/file" /usr/bin/file
+    _clean_file=true
+  fi
+}
+
+do_check() {
+  make check
+}
+
+do_end() {
+  if [[ -n "${_clean_file}" ]]; then
+    rm -fv /usr/bin/file
+  fi
+}

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,14 @@
+@test "libraries are dynamically linked" {
+  run ldd /hab/pkgs/$TEST_PKG_IDENT/lib/libasound.so*
+  [ $status -eq 0 ]
+}
+
+@test "aserver is dynamically linked" {
+  run ldd /hab/pkgs/$TEST_PKG_IDENT/bin/aserver
+  [ $status -eq 0 ]
+}
+
+@test "aserver help command works" {
+  run /hab/pkgs/$TEST_PKG_IDENT/bin/aserver --help
+  [ $status -eq 0 ]
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -euo pipefail
+
+TESTDIR="$(dirname "${0}")"
+
+if [ -z "${1:-}" ]; then
+  echo "Usage: $0 FULLY_QUALIFIED_PACKAGE_IDENT"
+  exit 1
+fi
+
+TEST_PKG_IDENT="$1"
+
+hab pkg install core/bats --binlink
+hab pkg install "$TEST_PKG_IDENT"
+
+export TEST_PKG_IDENT
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
**Until azuredevops pipeline issue is resolved, keeping this as draft**

All tests passing on local studio:

```rspec
Profile: Habitat Core Plan alsa-lib (alsa-lib)
Version: 0.1.0
Target:  local://

  ✔  core-plans-alsa-lib-exists: Ensure alsa-lib exists
     ✔  Command: `hab pkg path core/alsa-lib` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/alsa-lib` stdout is expected not to be empty
     ✔  Command: `hab pkg path core/alsa-lib` stderr is expected to be empty
     ✔  File /hab/pkgs/core/alsa-lib/1.1.9/20200811102940/bin/aserver is expected to exist
     ✔  File /hab/pkgs/core/alsa-lib/1.1.9/20200811102940/bin/aserver is expected to be executable
  ✔  core-plans-alsa-lib-works: Ensure alsa-lib works as expected
     ✔  Command: `hab pkg path core/alsa-lib` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/alsa-lib` stdout is expected not to be empty
     ✔  Command: `hab pkg path core/alsa-lib` stderr is expected to be empty
     ✔  Command: `/hab/pkgs/core/alsa-lib/1.1.9/20200811102940/bin/aserver --help` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/core/alsa-lib/1.1.9/20200811102940/bin/aserver --help` stderr is expected not to be empty
     ✔  Command: `/hab/pkgs/core/alsa-lib/1.1.9/20200811102940/bin/aserver --help` stderr is expected to match /Usage:\s+[^\s]*\s+\[OPTIONS\]\s+server/
     ✔  Command: `/hab/pkgs/core/alsa-lib/1.1.9/20200811102940/bin/aserver --help` stdout is expected to be empty
  ✔  core-plans-alsa-lib-library-exists: Ensure alsa-lib library exists
     ✔  Command: `hab pkg path core/alsa-lib` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/alsa-lib` stdout is expected not to be empty
     ✔  File /hab/pkgs/core/alsa-lib/1.1.9/20200811102940/lib/libasound.so is expected to exist
     ✔  Command: `cat /hab/pkgs/core/alsa-lib/1.1.9/20200811102940/lib/pkgconfig/alsa.pc` exit_status is expected to eq 0
     ✔  Command: `cat /hab/pkgs/core/alsa-lib/1.1.9/20200811102940/lib/pkgconfig/alsa.pc` stdout is expected not to be empty
     ✔  Command: `cat /hab/pkgs/core/alsa-lib/1.1.9/20200811102940/lib/pkgconfig/alsa.pc` stdout is expected to match /Version: 1.1.9/
     ✔  Command: `cat /hab/pkgs/core/alsa-lib/1.1.9/20200811102940/lib/pkgconfig/alsa.pc` stderr is expected to be empty


Profile Summary: 3 successful controls, 0 control failures, 0 controls skipped
Test Summary: 19 successful, 0 failures, 0 skipped
[10][default:/src/alsa-lib:0]# 
```

but on azure devops pipeline, some of the stderr tests are failing because of know issue.  For example:

```rspec
   ×  Command: `hab pkg path base/alsa-lib` stderr is expected to be empty
     expected `"/opt/inspec/embedded/lib/ruby/gems/2.6.0/gems/mixlib-shellout-3.1.2/lib/mixlib/shellout/unix.rb:343: warning: Insecure world writable dir /home/linuxbrew/.linuxbrew in PATH, mode 040777\n".empty?` to return true, got false
```